### PR TITLE
stick to jwt-go v2

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/dgrijalva/jwt-go"
+	"gopkg.in/dgrijalva/jwt-go.v2"
 )
 
 const (


### PR DESCRIPTION
I was getting : 
```
# github.com/alternaDev/go-firebase-verify
../../../github.com/alternaDev/go-firebase-verify/verify.go:50: invalid operation: parsedToken.Claims["aud"] (type jwt.Claims does not support indexing)
../../../github.com/alternaDev/go-firebase-verify/verify.go:51: invalid operation: parsedToken.Claims["aud"] (type jwt.Claims does not support indexing)
../../../github.com/alternaDev/go-firebase-verify/verify.go:52: invalid operation: parsedToken.Claims["iss"] (type jwt.Claims does not support indexing)
../../../github.com/alternaDev/go-firebase-verify/verify.go:54: invalid operation: parsedToken.Claims["sub"] (type jwt.Claims does not support indexing)
../../../github.com/alternaDev/go-firebase-verify/verify.go:62: invalid operation: parsedToken.Claims["sub"] (type jwt.Claims does not support indexing)
```

Instructions for upgrading to v3 are here : https://github.com/dgrijalva/jwt-go/blob/master/MIGRATION_GUIDE.md

But until then it can still be pinned to v2 using gopkg.in 😃 